### PR TITLE
Track whether blind is added to `hass` before updating. Fix race cond.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.2] - 2021-12-23
+### Fixed
+* Added (hacky) check to verify entity has been added to Home Assistant before attempting to update state.
+
 ## [1.0.1] - 2021-12-19
 ### Changed
 * (Re-)Added support for `cover.open_cover` and `cover.close_cover` to make it easier to script open/close events

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cover:
 ```
 
 
-## Troublshooting
+## Troubleshooting
 To turn on debug logging, modify your `configuration.yaml` and add the following:
 ```yaml
 logger:

--- a/custom_components/mysmartblinds/manifest.json
+++ b/custom_components/mysmartblinds/manifest.json
@@ -5,5 +5,5 @@
   "requirements": ["smartblinds-client==0.6"],
   "dependencies": [],
   "codeowners": ["@ianlevesque", "@docbliny"],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }


### PR DESCRIPTION
This is a hacky, quick and dirty fix attempt to avoid entities from trying to update their state before they've been added to Home Assistant. It should resolve the following error:
```
Traceback (most recent call last):

File “/usr/local/lib/python3.9/concurrent/futures/thread.py”, line 52, in run

result = self.fn(*self.args, **self.kwargs)

File “/config/custom_components/mysmartblinds/cover.py”, line 102, in wrapper

return func(*args, **kwargs)

File “/config/custom_components/mysmartblinds/cover.py”, line 201, in _set_blind_positions

entity.schedule_update_ha_state(force_refresh=True)

File “/usr/src/homeassistant/homeassistant/helpers/entity.py”, line 643, in schedule_update_ha_state

self.hass.add_job(self.async_update_ha_state(force_refresh)) # type: ignore

AttributeError: ‘NoneType’ object has no attribute ‘add_job’
```

The component needs a rewrite based on:
* https://github.com/home-assistant/example-custom-config/blob/master/custom_components/detailed_hello_world_push/cover.py
* https://developers.home-assistant.io/docs/integration_fetching_data/